### PR TITLE
chore: remove incorrect changelog 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-### Added
-- StandardDatumReceiver contract
 
 ## [3.8.0] - 2022-06-10
 ### Added


### PR DESCRIPTION
When finished release 3.8.0 the merge main to develop added the unreleased message again.
It probably happened because release 3.7.0 wasn't finished using hubflow.
https://github.com/umbrella-network/babel/commit/8aee7d94d7cf7a1a61b01c726116c27de3ce073f
